### PR TITLE
Bump System.Text.Json from 8.0.4 to 8.0.5 in /src

### DIFF
--- a/src/Evanston/Evanston.csproj
+++ b/src/Evanston/Evanston.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="MudBlazor" Version="7.8.0" />
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="Riok.Mapperly" Version="3.6.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="ValueOf" Version="2.0.31" />
   </ItemGroup>
 


### PR DESCRIPTION
* Bump System.Text.Json from 8.0.4 to 8.0.5 in /src

Bumps [System.Text.Json](https://github.com/dotnet/runtime) from 8.0.4 to 8.0.5.
- [Release notes](https://github.com/dotnet/runtime/releases)
- [Commits](https://github.com/dotnet/runtime/compare/v8.0.4...v8.0.5)

---
updated-dependencies:
- dependency-name: System.Text.Json dependency-type: direct:production update-type: version-update:semver-patch ...



---------