### PR TITLE
Bump PublishSPAforGitHubPages.Build from 3.0.1 to 3.0.3

### DIFF
--- a/src/Evanston/Evanston.csproj
+++ b/src/Evanston/Evanston.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.9" PrivateAssets="all" />
     <PackageReference Include="MudBlazor" Version="8.12.0" />
     <PackageReference Include="OneOf" Version="3.0.271" />
-    <PackageReference Include="PublishSPAforGitHubPages.Build" Version="3.0.1" />
+    <PackageReference Include="PublishSPAforGitHubPages.Build" Version="3.0.3" />
     <PackageReference Include="Riok.Mapperly" Version="4.2.1" />
     <PackageReference Include="System.Text.Json" Version="9.0.9" />
     <PackageReference Include="ValueOf" Version="2.0.31" />


### PR DESCRIPTION
---
updated-dependencies:
- dependency-name: PublishSPAforGitHubPages.Build dependency-version: 3.0.3 dependency-type: direct:production update-type: version-update:semver-patch ...